### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ python3 -m http.server
 ```
 
 Then visit [http://localhost:8000](http://localhost:8000) to explore the experience.
+
+## Deploying to GitHub Pages
+
+This repository is preconfigured with a GitHub Actions workflow that publishes the static site to GitHub Pages on every push to the `main` branch.
+
+1. Push the repository to GitHub if you have not already.
+2. In your GitHub repository, navigate to **Settings → Pages** and choose **GitHub Actions** as the source. Save the settings.
+3. Trigger the workflow by pushing to `main` (or run it manually from the **Actions** tab). The workflow uploads the repository contents as a static artifact and deploys it to the special `github-pages` environment.
+4. Once the workflow completes, the deployed site URL appears in the workflow summary and on the **Pages** settings screen.
+
+If you prefer a custom domain, configure it in **Settings → Pages → Custom domain** and add the appropriate DNS records.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys the static site to GitHub Pages on pushes to main
- document the Pages deployment process in the README for easy setup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cdeb675f2c8330bfd29fbd4006848b